### PR TITLE
Add --version flag to display installed version of Maggy

### DIFF
--- a/src/commands.php
+++ b/src/commands.php
@@ -5,6 +5,10 @@ function help(): void {
 	echo "\thelp — show this message\n";
 }
 
+function maggy_version(): void {
+    echo "Maggy v0.1.1-alpha\n";
+}
+
 function setup(): void {
 	$has_config = file_exists('./config.ini');
 	$has_migrations = file_exists('./migration');

--- a/src/maggy.php
+++ b/src/maggy.php
@@ -40,6 +40,10 @@ switch ($command) {
 			help();
 			break;
 		}
+		if (isset($flags['version']) || isset($flags['v'])) {
+			maggy_version();
+			break;
+		}
 		break;
 	case 'help':
 		help();


### PR DESCRIPTION
Adds the command `maggy --version` or `maggy -v` to display the currently installed version of Maggy, e.g., `Maggy v0.1.1-alpha`.